### PR TITLE
use generic container

### DIFF
--- a/src/BasePathViewHelperFactory.php
+++ b/src/BasePathViewHelperFactory.php
@@ -6,11 +6,10 @@ use Interop\Container\ContainerInterface;
 
 class BasePathViewHelperFactory
 {
-    public function __invoke(ContainerInterface $services)
+    public function __invoke(ContainerInterface $container)
     {
-        $sl = $services->getServiceLocator();
         return new BasePathViewHelper(
-            $sl->get(BasePathHelper::class)
+            $container->get(BasePathHelper::class)
         );
     }
 }


### PR DESCRIPTION
then in `templates.global.php`

(edited)

``` php
return [
    'dependencies' => [
        'invokables' => [
            // setup factory
            Blast\BaseUrl\BasePathHelper::class => Blast\BaseUrl\BasePathHelper::class,            
        ],        
    ],
    // for zend-view
    'view_helpers => [
        'factories' => [
            Blast\BaseUrl\BasePathViewHelper::class => Blast\BaseUrl\BasePathViewHelperFactory::class,            
        ],        
        'aliases' => [
            'basePath' => Blast\BaseUrl\BasePathViewHelper::class,
        ],
    ],
];
```

this make also easy to register a template function in Plates.
