### PR TITLE
use the request uri component

### DIFF
--- a/src/BaseUrlFinder.php
+++ b/src/BaseUrlFinder.php
@@ -17,53 +17,6 @@ class BaseUrlFinder
         return null;
     }
 
-    private function detectRequestUri()
-    {
-        $requestUri = null;
-
-        // Check this first so IIS will catch.
-        $httpXRewriteUrl = $this->getServer('HTTP_X_REWRITE_URL');
-        if ($httpXRewriteUrl !== null) {
-            $requestUri = $httpXRewriteUrl;
-        }
-
-        // Check for IIS 7.0 or later with ISAPI_Rewrite
-        $httpXOriginalUrl = $this->getServer('HTTP_X_ORIGINAL_URL');
-        if ($httpXOriginalUrl !== null) {
-            $requestUri = $httpXOriginalUrl;
-        }
-
-        // IIS7 with URL Rewrite: make sure we get the unencoded url
-        // (double slash problem).
-        $iisUrlRewritten = $this->getServer('IIS_WasUrlRewritten');
-        $unencodedUrl    = $this->getServer('UNENCODED_URL') ? : '';
-        if ('1' == $iisUrlRewritten && '' !== $unencodedUrl) {
-            return $unencodedUrl;
-        }
-
-        // HTTP proxy requests setup request URI with scheme and host [and port]
-        // + the URL path, only use URL path.
-        if (!$httpXRewriteUrl) {
-            $requestUri = $this->getServer('REQUEST_URI');
-        }
-
-        if ($requestUri !== null) {
-            return preg_replace('#^[^/:]+://[^/]+#', '', $requestUri);
-        }
-
-        // IIS 5.0, PHP as CGI.
-        $origPathInfo = $this->getServer('ORIG_PATH_INFO');
-        if ($origPathInfo !== null) {
-            $queryString = $this->getServer('QUERY_STRING') ? : '';
-            if ($queryString !== '') {
-                $origPathInfo .= '?' . $queryString;
-            }
-            return $origPathInfo;
-        }
-
-        return '/';
-    }
-
     /**
      * Auto-detect the base path from the request environment
      *

--- a/src/BaseUrlFinder.php
+++ b/src/BaseUrlFinder.php
@@ -25,10 +25,10 @@ class BaseUrlFinder
      *
      *
      * @param array $serverParams
-     * @param array $uriPath The server request uri component path
+     * @param string $uriPath The server request uri component path
      * @return string
      */
-    public function findBaseUrl($serverParams = [], $uriPath)
+    public function findBaseUrl(array $serverParams, $uriPath)
     {
         $this->server = $serverParams;
 

--- a/src/BaseUrlFinder.php
+++ b/src/BaseUrlFinder.php
@@ -72,9 +72,10 @@ class BaseUrlFinder
      *
      *
      * @param array $serverParams
+     * @param array $uriPath The server request uri component path
      * @return string
      */
-    public function findBaseUrl($serverParams = [])
+    public function findBaseUrl($serverParams = [], $uriPath)
     {
         $this->server = $serverParams;
 
@@ -108,40 +109,31 @@ class BaseUrlFinder
             return '';
         }
 
-        // Does the base URL have anything in common with the request URI?
-        $requestUri = $this->detectRequestUri();
-
         // Full base URL matches.
-        if (0 === strpos($requestUri, $baseUrl)) {
+        if (0 === strpos($uriPath, $baseUrl)) {
             return $baseUrl;
         }
 
         // Directory portion of base path matches.
         $baseDir = str_replace('\\', '/', dirname($baseUrl));
-        if (0 === strpos($requestUri, $baseDir)) {
+        if (0 === strpos($uriPath, $baseDir)) {
             return $baseDir;
-        }
-
-        $truncatedRequestUri = $requestUri;
-
-        if (false !== ($pos = strpos($requestUri, '?'))) {
-            $truncatedRequestUri = substr($requestUri, 0, $pos);
         }
 
         $basename = basename($baseUrl);
 
         // No match whatsoever
-        if (empty($basename) || false === strpos($truncatedRequestUri, $basename)) {
+        if (empty($basename) || false === strpos($uriPath, $basename)) {
             return '';
         }
 
         // If using mod_rewrite or ISAPI_Rewrite strip the script filename
         // out of the base path. $pos !== 0 makes sure it is not matching a
         // value from PATH_INFO or QUERY_STRING.
-        if (strlen($requestUri) >= strlen($baseUrl)
-            && (false !== ($pos = strpos($requestUri, $baseUrl)) && $pos !== 0)
+        if (strlen($uriPath) >= strlen($baseUrl)
+            && (false !== ($pos = strpos($uriPath, $baseUrl)) && $pos !== 0)
         ) {
-            $baseUrl = substr($requestUri, 0, $pos + strlen($baseUrl));
+            $baseUrl = substr($uriPath, 0, $pos + strlen($baseUrl));
         }
 
         return $baseUrl;

--- a/src/BaseUrlMiddleware.php
+++ b/src/BaseUrlMiddleware.php
@@ -73,16 +73,19 @@ class BaseUrlMiddleware
 
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
-        $baseUrl = $this->baseUrlFinder->findBaseUrl($request->getServerParams());
+        $uri = $request->getUri();
+        $uriPath = $uri->getPath();
+
+        $baseUrl  = $this->baseUrlFinder->findBaseUrl($request->getServerParams(), $uriPath);
         $basePath = $this->detectBasePath($request->getServerParams(), $baseUrl);
 
         $request = $request->withAttribute(self::BASE_URL, $baseUrl);
         $request = $request->withAttribute(self::BASE_PATH, $basePath);
 
-        if (!empty($baseUrl) && strpos($request->getUri()->getPath(), $baseUrl) === 0) {
-            $path = substr($request->getUri()->getPath(), strlen($baseUrl));
+        if (!empty($baseUrl) && strpos($uriPath, $baseUrl) === 0) {
+            $path = substr($uriPath, strlen($baseUrl));
             $path = '/' . ltrim($path, '/');
-            $request = $request->withUri($request->getUri()->withPath($path));
+            $request = $request->withUri($uri->withPath($path));
         }
 
         if ($this->urlHelper) {

--- a/test/BaseUrlFinderTest.php
+++ b/test/BaseUrlFinderTest.php
@@ -160,7 +160,7 @@ class BaseUrlFinderTest extends PHPUnit_Framework_TestCase
     public function testBasePathDetection(array $server, $baseUrl)
     {
         $request = ServerRequestFactory::fromGlobals($server);
-        $result = (new BaseUrlFinder())->findBaseUrl($server, $$request->getUri()->getPath());
+        $result = (new BaseUrlFinder())->findBaseUrl($server, $request->getUri()->getPath());
         $this->assertEquals($baseUrl, $result);
     }
 }

--- a/test/BaseUrlFinderTest.php
+++ b/test/BaseUrlFinderTest.php
@@ -4,6 +4,7 @@ namespace Blast\Test\BaseUrl;
 
 use Blast\BaseUrl\BaseUrlFinder;
 use PHPUnit_Framework_TestCase;
+use Zend\Diactoros\ServerRequestFactory;
 
 class BaseUrlFinderTest extends PHPUnit_Framework_TestCase
 {
@@ -158,7 +159,8 @@ class BaseUrlFinderTest extends PHPUnit_Framework_TestCase
      */
     public function testBasePathDetection(array $server, $baseUrl)
     {
-        $result = (new BaseUrlFinder())->findBaseUrl($server);
+        $request = ServerRequestFactory::fromGlobals($server);
+        $result = (new BaseUrlFinder())->findBaseUrl($server, $$request->getUri()->getPath());
         $this->assertEquals($baseUrl, $result);
     }
 }


### PR DESCRIPTION
The UriInterface component of the server request has already a path stripped of the query string.
See zend-diactoros ServerRequestFactory 

``` php
        // URI path
        $path = self::marshalRequestUri($server);
        $path = self::stripQueryString($path);
```

`marshalRequestUri` already does what the finder detectRequestUri() does and sends the result to the path property of the uri component.

I believe we should analyze the passed as argument $request->getUri() component path property instead of rebuilding again the request uri (and using the same code).
