### PR TITLE
Update BasePathTwigExtension.php

### DIFF
--- a/src/BasePathTwigExtension.php
+++ b/src/BasePathTwigExtension.php
@@ -21,9 +21,9 @@ class BasePathTwigExtension extends AbstractExtension
 
     public function getFunctions()
     {
-        return array(
-            new TwigFunction('basePath', array($this, 'render')),
-        );
+        return [
+            new TwigFunction('basePath', [$this, 'render']),
+        ];
     }
 
     public function render(string $assetUrl = '')


### PR DESCRIPTION
Short array syntax must be used to define arrays.

Fix issue with PHP-CS brought in #17 